### PR TITLE
fix: display location in the waring statements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sphinx-btn"
 version = "0.1.1"
 description = "A sphinx custom role to embed inline btn which is an icon in a guilabel in the latex and html outputs"
 requires-python = ">=3.6.9"
-dependencies = ["sphinx", "sphinx-icon"]
+dependencies = ["sphinx", "sphinx-icon>=0.2.2"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Sphinx :: Extension",

--- a/sphinxcontrib/btn/btn.py
+++ b/sphinxcontrib/btn/btn.py
@@ -34,7 +34,9 @@ class Btn(SphinxRole):
 
         # build the node with sanitized strings
         node = btn_node(
-            icon=icon.replace("<", "").replace(">", ""), title=title.strip()
+            icon=icon.replace("<", "").replace(">", ""),
+            title=title.strip(),
+            location=self.get_source_info(),
         )
 
         return [node], []
@@ -47,8 +49,9 @@ def visit_btn_node_html(translator: SphinxTranslator, node: btn_node) -> None:
 
     # add the icon if existing
     if node["icon"]:
-        icon.visit_icon_node_html(translator, icon.icon_node(icon=node["icon"]))
-        icon.depart_icon_node_html(translator, icon.icon_node(icon=node["icon"]))
+        icon_node = icon.icon_node(icon=node["icon"], location=node["location"])
+        icon.visit_icon_node_html(translator, icon_node)
+        icon.depart_icon_node_html(translator, icon_node)
 
     # add the title if existing
     if node["title"]:
@@ -68,8 +71,9 @@ def visit_btn_node_latex(translator: SphinxTranslator, node: btn_node) -> None:
 
     # add the icon if existing
     if node["icon"]:
-        icon.visit_icon_node_latex(translator, icon.icon_node(icon=node["icon"]))
-        icon.depart_icon_node_latex(translator, icon.icon_node(icon=node["icon"]))
+        icon_node = icon.icon_node(icon=node["icon"], location=node["location"])
+        icon.visit_icon_node_latex(translator, icon_node)
+        icon.depart_icon_node_latex(translator, icon_node)
 
     # add the title if existing
     if node["title"]:
@@ -84,7 +88,9 @@ def depart_btn_node_latex(translator: SphinxTranslator, node: btn_node) -> None:
 
 def visit_btn_node_unsuported(translator: SphinxTranslator, node: btn_node) -> None:
     """Raise error when the requested output is not supported."""
-    logger.warning("Unsupported output format (node skipped)")
+    logger.warning(
+        "Unsupported output format (node skipped)", location=node["location"]
+    )
     raise nodes.SkipNode
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -28,8 +28,8 @@ def test_btn_latex(app, status, warning):
         in result
     )
 
-    assert r'\sphinxbtn{{\solid\symbol{"F07B}} fa-folder}' in result
-    assert r'\sphinxbtn{{\solid\symbol{"F07B}}}' in result
+    assert r'\sphinxbtn{{\fasolid\symbol{"F07B}} fa-folder}' in result
+    assert r'\sphinxbtn{{\fasolid\symbol{"F07B}}}' in result
     assert r"\sphinxbtn{fa-folder}" in result
 
 


### PR DESCRIPTION
Fix #12 

simply pass the location to the icon node so that locations of warnings are displayed